### PR TITLE
Fetch openpath token and provision device

### DIFF
--- a/lib/features/base/presentation/pages/demo/openpath_bridge.dart
+++ b/lib/features/base/presentation/pages/demo/openpath_bridge.dart
@@ -18,6 +18,32 @@ class OpenpathEvent {
     );
   }
 
+  Map<String, dynamic> toJson() {
+    return {
+      'event': event,
+      'data': _encodeForJson(data),
+    };
+  }
+
+  static dynamic _encodeForJson(dynamic value) {
+    if (value == null || value is num || value is bool || value is String) {
+      return value;
+    }
+    if (value is Map) {
+      return value.map((key, v) => MapEntry(key.toString(), _encodeForJson(v)));
+    }
+    if (value is Iterable) {
+      return value.map(_encodeForJson).toList();
+    }
+    try {
+      final dynamic maybeToJson = (value as dynamic).toJson;
+      if (maybeToJson is Function) {
+        return maybeToJson();
+      }
+    } catch (_) {}
+    return value.toString();
+  }
+
   @override
   String toString() => 'OpenpathEvent(event: $event, data: $data)';
 }


### PR DESCRIPTION
Add `toJson()` method to `OpenpathEvent` to enable JSON serialization and prevent `Converting object to an encodable object failed` errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-055342ab-5d93-48d2-87eb-9cda880c8f36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-055342ab-5d93-48d2-87eb-9cda880c8f36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

