### PR TITLE
Initialize and provision openpath foreground service

### DIFF
--- a/lib/features/base/presentation/pages/demo/openpath_bridge.dart
+++ b/lib/features/base/presentation/pages/demo/openpath_bridge.dart
@@ -187,13 +187,14 @@ class OpenpathBridge {
 
     // Ensure the SDK foreground service is started before provisioning
     await initialize();
-    await Future.delayed(const Duration(milliseconds: 200));
+    await Future.delayed(const Duration(milliseconds: 400));
 
     const backoff = <Duration>[
-      Duration(milliseconds: 200),
-      Duration(milliseconds: 400),
-      Duration(milliseconds: 800),
-      Duration(milliseconds: 1600),
+      Duration(milliseconds: 300),
+      Duration(milliseconds: 600),
+      Duration(milliseconds: 900),
+      Duration(milliseconds: 1300),
+      Duration(milliseconds: 2000),
     ];
 
     for (int i = 0; i < backoff.length; i++) {


### PR DESCRIPTION
Implement non-blocking retry logic for Openpath SDK provisioning on Android and adjust Dart bridge delays to prevent "foreground service is null" errors.

The Openpath SDK's foreground service sometimes isn't fully initialized when `provision` is called, leading to a `foreground service is null` error. This PR introduces a robust retry mechanism on the Android side, executed on a background thread with exponential backoff, and slightly extends the initial wait and backoff sequence on the Dart side to give the service more time to become ready.

---
<a href="https://cursor.com/background-agent?bcId=bc-bda61f32-e37f-468e-b4ac-4d8e05481111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bda61f32-e37f-468e-b4ac-4d8e05481111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

