### PR TITLE
Initialize and provision openpath foreground service

### DIFF
--- a/lib/features/base/presentation/pages/demo/openpath_bridge.dart
+++ b/lib/features/base/presentation/pages/demo/openpath_bridge.dart
@@ -187,14 +187,14 @@ class OpenpathBridge {
 
     // Ensure the SDK foreground service is started before provisioning
     await initialize();
-    await Future.delayed(const Duration(milliseconds: 1200));
+    await Future.delayed(const Duration(milliseconds: 2000));
 
     const backoff = <Duration>[
-      Duration(milliseconds: 800),
-      Duration(milliseconds: 1500),
-      Duration(milliseconds: 2500),
-      Duration(milliseconds: 4000),
-      Duration(milliseconds: 6000),
+      Duration(milliseconds: 1000),
+      Duration(milliseconds: 2000),
+      Duration(milliseconds: 3000),
+      Duration(milliseconds: 5000),
+      Duration(milliseconds: 8000),
     ];
 
     for (int i = 0; i < backoff.length; i++) {


### PR DESCRIPTION
Fixes "foreground service is null" error during OpenPath SDK provisioning by ensuring the Android foreground service is fully initialized and bound before SDK operations.

The `OpenpathMobileAccessCore.getInstance()` was being called before the Android foreground service was fully initialized and its reference was available to the SDK, leading to a `NullPointerException` during the `provision` call. This PR enhances service initialization with binding, improves SDK context initialization, and adds more robust retry logic with increased delays to ensure the service is ready.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a1024c1-5b9b-4a9c-814d-c0666b33941b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2a1024c1-5b9b-4a9c-814d-c0666b33941b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

