### PR TITLE
Initialize and provision openpath sdk

### DIFF
--- a/lib/features/base/presentation/pages/demo/openpath_bridge.dart
+++ b/lib/features/base/presentation/pages/demo/openpath_bridge.dart
@@ -119,12 +119,12 @@ class OpenpathBridge {
       _rawEvents.map((m) => OpenpathEvent.fromJson(m));
 
   // ----- Permissions / toggles -----
-  /// ✅ dummy permissions always return ok because v0.5.0 SDK doesn’t handle them
+  /// Request required permissions for OpenPath SDK (Bluetooth, Location, Notifications)
   static Future<bool> requestPermissions() async {
     try {
-      return await _method.invokeMethod<bool>('requestPermissions') ?? true;
+      return await _method.invokeMethod<bool>('requestPermissions') ?? false;
     } catch (_) {
-      return true;
+      return false;
     }
   }
 
@@ -134,13 +134,13 @@ class OpenpathBridge {
         await _method.invokeMethod('getPermissionStatus'),
       );
     } catch (_) {
-      // fallback dummy data
+      // fallback conservative data - assume permissions not granted
       return {
-        'btOn': true,
-        'locationOn': true,
-        'notificationsOn': true,
-        'baseOk': true,
-        'bgOk': true,
+        'btOn': false,
+        'locationOn': false,
+        'notificationsOn': false,
+        'baseOk': false,
+        'bgOk': false,
       };
     }
   }
@@ -179,6 +179,18 @@ class OpenpathBridge {
     String? opal,
     String? deviceToken,
   }) async {
+    // Check permissions first before attempting provision
+    final permissionStatus = await getPermissionStatus();
+    if (!permissionStatus['btOn'] || !permissionStatus['locationOn']) {
+      print("Required permissions not granted - Bluetooth: ${permissionStatus['btOn']}, Location: ${permissionStatus['locationOn']}");
+      // Request permissions if not granted
+      final permissionsGranted = await requestPermissions();
+      if (!permissionsGranted) {
+        print("Failed to obtain required permissions for OpenPath SDK");
+        return false;
+      }
+    }
+
     final args = <String, dynamic>{
       'jwt': jwt.trim(),
       'opal': opal ?? extractOpalFromJwt(jwt),

--- a/lib/openpath/openpath_service.dart
+++ b/lib/openpath/openpath_service.dart
@@ -25,6 +25,7 @@ class OpenpathService {
   }
 
   static Future<Map<String,dynamic>?> provision(String token) async {
+    // Always check permissions first, regardless of which provision method we use
     if (!await _ensurePermissions()) {
       throw Exception('Permissions denied');
     }


### PR DESCRIPTION
Enforce Bluetooth and Location permissions for OpenPath SDK provisioning.

Previously, the SDK could provision without requesting these critical permissions due to a bypassed permission check in the Flutter layer and dummy implementations in the Android plugin. This PR ensures all necessary permissions are explicitly checked and requested before provisioning, preventing the SDK from operating without required access.

---
<a href="https://cursor.com/background-agent?bcId=bc-43d7559c-293a-4c22-bb9f-3a8cb3286b6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-43d7559c-293a-4c22-bb9f-3a8cb3286b6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

