### PR TITLE
Handle openpath sdk permission issues

### DIFF
--- a/lib/features/base/presentation/pages/demo/open_path_demo.dart
+++ b/lib/features/base/presentation/pages/demo/open_path_demo.dart
@@ -74,7 +74,25 @@ class _OpenpathDemoAppState extends State<OpenpathDemoApp> {
   }
 
   Future<void> _ensureReady() async {
-    await OpenpathBridge.requestPermissions();
+    setState(() {
+      log += 'Requesting permissions...\n';
+      _autoScrollLog();
+    });
+    
+    final permissionsGranted = await OpenpathBridge.requestPermissions();
+    setState(() {
+      log += 'Permissions granted: $permissionsGranted\n';
+      _autoScrollLog();
+    });
+    
+    if (!permissionsGranted) {
+      setState(() {
+        log += '⚠️ Required permissions not granted. Please enable Bluetooth and Location permissions in settings.\n';
+        _autoScrollLog();
+      });
+      return;
+    }
+    
     await OpenpathBridge.initialize();
     await _refreshPermissionStatus();
   }
@@ -181,6 +199,45 @@ class _OpenpathDemoAppState extends State<OpenpathDemoApp> {
                     txtColor: context.colors.white,
                     textSize: 15.sp,
                     maxHeight: 52.h,
+                  ),
+                  Gaps.vGap16,
+                  
+                  // Permission management buttons
+                  Row(
+                    children: [
+                      Expanded(
+                        child: AppTextButton.maxCustom(
+                          onPressed: () async {
+                            setState(() {
+                              log += 'Manually requesting permissions...\n';
+                              _autoScrollLog();
+                            });
+                            final granted = await OpenpathBridge.requestPermissions();
+                            setState(() {
+                              log += 'Manual permission request result: $granted\n';
+                              _autoScrollLog();
+                            });
+                            await _refreshPermissionStatus();
+                          },
+                          text: 'Request Permissions',
+                          bgColor: context.colors.primary,
+                          txtColor: context.colors.white,
+                          textSize: 12.sp,
+                          maxHeight: 40.h,
+                        ),
+                      ),
+                      Gaps.hGap8,
+                      Expanded(
+                        child: AppTextButton.maxCustom(
+                          onPressed: _refreshPermissionStatus,
+                          text: 'Check Status',
+                          bgColor: context.colors.primary,
+                          txtColor: context.colors.white,
+                          textSize: 12.sp,
+                          maxHeight: 40.h,
+                        ),
+                      ),
+                    ],
                   ),
                   Gaps.vGap16,
 

--- a/lib/features/base/presentation/pages/demo/openpath_bridge.dart
+++ b/lib/features/base/presentation/pages/demo/openpath_bridge.dart
@@ -189,6 +189,13 @@ class OpenpathBridge {
         print("Failed to obtain required permissions for OpenPath SDK");
         return false;
       }
+      
+      // Re-check permissions after request to ensure they were actually granted
+      final updatedPermissionStatus = await getPermissionStatus();
+      if (!updatedPermissionStatus['btOn'] || !updatedPermissionStatus['locationOn']) {
+        print("Permissions still not granted after request - Bluetooth: ${updatedPermissionStatus['btOn']}, Location: ${updatedPermissionStatus['locationOn']}");
+        return false;
+      }
     }
 
     final args = <String, dynamic>{

--- a/lib/openpath/openpath_service.dart
+++ b/lib/openpath/openpath_service.dart
@@ -11,17 +11,14 @@ class OpenpathService {
   static const _channel = MethodChannel('openpath');
 
   static Future<bool> _ensurePermissions() async {
-    if (await Permission.bluetooth.isGranted &&
-        await Permission.bluetoothScan.isGranted &&
-        await Permission.bluetoothConnect.isGranted) return true;
-    final statuses = await [
-      Permission.bluetooth,
-      Permission.bluetoothScan,
-      Permission.bluetoothConnect,
-      Permission.locationWhenInUse,
-      Permission.notification,
-    ].request();
-    return statuses.values.every((s) => s.isGranted);
+    // Use the native plugin's permission handling instead of permission_handler
+    // to avoid conflicts and ensure proper OpenPath SDK integration
+    try {
+      return await _channel.invokeMethod<bool>('requestPermissions') ?? false;
+    } catch (e) {
+      print('Failed to request permissions via native plugin: $e');
+      return false;
+    }
   }
 
   static Future<Map<String,dynamic>?> provision(String token) async {


### PR DESCRIPTION
Fix OpenPath SDK permission handling to correctly request and validate Bluetooth and Location permissions before provisioning.

Previously, the app would report successful OpenPath SDK provisioning even when required Bluetooth and Location permissions were not granted. This was due to the native Android plugin immediately returning `false` for permission requests without waiting for user input, a missing callback to handle permission results, and conflicts arising from using both `permission_handler` and native plugin calls for permissions. This PR unifies permission handling through the native plugin, ensures the app waits for user responses, and validates that permissions are granted before proceeding with SDK provisioning.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d605b80-632c-4f48-91d5-2cf3ef48a56d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5d605b80-632c-4f48-91d5-2cf3ef48a56d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

