### PR TITLE
Initialize openpath foreground service

### DIFF
--- a/lib/features/base/presentation/pages/demo/openpath_bridge.dart
+++ b/lib/features/base/presentation/pages/demo/openpath_bridge.dart
@@ -181,8 +181,9 @@ class OpenpathBridge {
   }) async {
     // Check permissions first before attempting provision
     final permissionStatus = await getPermissionStatus();
-    if (!permissionStatus['btOn'] || !permissionStatus['locationOn']) {
-      print("Required permissions not granted - Bluetooth: ${permissionStatus['btOn']}, Location: ${permissionStatus['locationOn']}");
+    if (!permissionStatus['baseOk']) {
+      print("Required permissions not granted - Bluetooth: ${permissionStatus['btOn']}, Location: ${permissionStatus['locationOn']}, Notifications: ${permissionStatus['notificationsOn']}");
+      
       // Request permissions if not granted
       final permissionsGranted = await requestPermissions();
       if (!permissionsGranted) {
@@ -192,8 +193,20 @@ class OpenpathBridge {
       
       // Re-check permissions after request to ensure they were actually granted
       final updatedPermissionStatus = await getPermissionStatus();
-      if (!updatedPermissionStatus['btOn'] || !updatedPermissionStatus['locationOn']) {
+      if (!updatedPermissionStatus['baseOk']) {
         print("Permissions still not granted after request - Bluetooth: ${updatedPermissionStatus['btOn']}, Location: ${updatedPermissionStatus['locationOn']}");
+        
+        // Guide user to enable services if needed
+        if (!updatedPermissionStatus['btOn']) {
+          print('Bluetooth not enabled, prompting user');
+          await promptEnableBluetooth();
+        }
+        
+        if (!updatedPermissionStatus['locationOn']) {
+          print('Location not enabled, opening settings');
+          await openLocationSettings();
+        }
+        
         return false;
       }
     }

--- a/lib/features/base/presentation/pages/open_path/open_path_controller.dart
+++ b/lib/features/base/presentation/pages/open_path/open_path_controller.dart
@@ -58,36 +58,56 @@ class OpenPathController {
   Future<bool> _ensurePermissions() async {
     if (!Platform.isAndroid) return true;
 
-    final sdk = (await DeviceInfoPlugin().androidInfo).version.sdkInt;
-
-    final toRequest = <Permission>[
-      if (sdk >= 31) ...[
-        Permission.bluetoothScan,
-        Permission.bluetoothConnect,
-        // Only if you actually advertise:
-        // Permission.bluetoothAdvertise,
-      ] else ...[
-        // Pre-Android 12 scanning maps to "location when in use"
-        Permission.locationWhenInUse,
-        Permission.bluetooth,
-      ],
-      // Recommended if your SDK shows a foreground notification:
-      Permission.notification,
-    ];
-
-    final statuses = await toRequest.request();
-    final denied = statuses.entries
-        .where((e) => e.value.isDenied || e.value.isPermanentlyDenied)
-        .map((e) => e.key)
-        .toList();
-
-    if (denied.isEmpty) return true;
-
-    // If permanently denied, prompt to Settings (optional)
-    if (denied.any((p) => statuses[p]!.isPermanentlyDenied)) {
-      await openAppSettings();
+    try {
+      // First check current permission status
+      final status = await _channel.invokeMethod<Map>('getPermissionStatus');
+      final permissionStatus = Map<String, dynamic>.from(status ?? {});
+      
+      print('Current permission status: $permissionStatus');
+      
+      // If permissions are already granted, return true
+      if (permissionStatus['baseOk'] == true) {
+        return true;
+      }
+      
+      // Request permissions if not granted
+      final permissionsGranted = await _channel.invokeMethod<bool>('requestPermissions') ?? false;
+      
+      if (!permissionsGranted) {
+        print('Permission request failed or denied');
+        return false;
+      }
+      
+      // Check status again after requesting permissions
+      final newStatus = await _channel.invokeMethod<Map>('getPermissionStatus');
+      final newPermissionStatus = Map<String, dynamic>.from(newStatus ?? {});
+      
+      print('Permission status after request: $newPermissionStatus');
+      
+      // If still not working, guide user to enable services
+      if (newPermissionStatus['baseOk'] != true) {
+        // Check if Bluetooth needs to be enabled
+        if (newPermissionStatus['btOn'] != true) {
+          print('Bluetooth not enabled, prompting user');
+          await _channel.invokeMethod('promptEnableBluetooth');
+          _toastError('Please enable Bluetooth and try again');
+        }
+        
+        // Check if Location needs to be enabled
+        if (newPermissionStatus['locationOn'] != true) {
+          print('Location not enabled, opening settings');
+          await _channel.invokeMethod('openLocationSettings');
+          _toastError('Please enable Location services and try again');
+        }
+        
+        return false;
+      }
+      
+      return true;
+    } catch (e) {
+      print('Failed to request permissions via native plugin: $e');
+      return false;
     }
-    return false;
   }
 
   /// Best-effort parse for credential details from the native message.
@@ -127,7 +147,7 @@ class OpenPathController {
   Future<void> provision(String token) async {
     final ok = await _ensurePermissions();
     if (!ok) {
-      _toastError('Bluetooth permissions denied');
+      _toastError('Required permissions denied. Please grant Bluetooth and Location permissions.');
       return;
     }
 

--- a/lib/features/base/presentation/pages/open_path/open_path_imports.dart
+++ b/lib/features/base/presentation/pages/open_path/open_path_imports.dart
@@ -26,7 +26,6 @@ import 'package:member360/core/widgets/app_button.dart';
 import 'package:member360/core/widgets/default_app_bar.dart';
 import 'package:member360/features/base/domain/repositories/base_repository.dart';
 import 'package:member360/openpath/openpath_service.dart';
-import 'package:permission_handler/permission_handler.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 part "open_path.dart";

--- a/lib/openpath/openpath_service.dart
+++ b/lib/openpath/openpath_service.dart
@@ -5,16 +5,55 @@ import 'package:member360/core/helpers/user_helper_service.dart';
 import 'package:member360/core/http/models/result.dart';
 import 'package:member360/features/base/domain/repositories/base_repository.dart';
 import 'package:member360/features/base/presentation/pages/demo/openpath_bridge.dart';
-import 'package:permission_handler/permission_handler.dart';
 
 class OpenpathService {
   static const _channel = MethodChannel('openpath');
 
   static Future<bool> _ensurePermissions() async {
-    // Use the native plugin's permission handling instead of permission_handler
-    // to avoid conflicts and ensure proper OpenPath SDK integration
     try {
-      return await _channel.invokeMethod<bool>('requestPermissions') ?? false;
+      // First check current permission status
+      final status = await _channel.invokeMethod<Map>('getPermissionStatus');
+      final permissionStatus = Map<String, dynamic>.from(status ?? {});
+      
+      print('Current permission status: $permissionStatus');
+      
+      // If permissions are already granted, return true
+      if (permissionStatus['baseOk'] == true) {
+        return true;
+      }
+      
+      // Request permissions if not granted
+      final permissionsGranted = await _channel.invokeMethod<bool>('requestPermissions') ?? false;
+      
+      if (!permissionsGranted) {
+        print('Permission request failed or denied');
+        return false;
+      }
+      
+      // Check status again after requesting permissions
+      final newStatus = await _channel.invokeMethod<Map>('getPermissionStatus');
+      final newPermissionStatus = Map<String, dynamic>.from(newStatus ?? {});
+      
+      print('Permission status after request: $newPermissionStatus');
+      
+      // If still not working, guide user to enable services
+      if (newPermissionStatus['baseOk'] != true) {
+        // Check if Bluetooth needs to be enabled
+        if (newPermissionStatus['btOn'] != true) {
+          print('Bluetooth not enabled, prompting user');
+          await _channel.invokeMethod('promptEnableBluetooth');
+        }
+        
+        // Check if Location needs to be enabled
+        if (newPermissionStatus['locationOn'] != true) {
+          print('Location not enabled, opening settings');
+          await _channel.invokeMethod('openLocationSettings');
+        }
+        
+        return false;
+      }
+      
+      return true;
     } catch (e) {
       print('Failed to request permissions via native plugin: $e');
       return false;


### PR DESCRIPTION
Unify OpenPath permission handling to use the native plugin and enhance user guidance for Bluetooth/Location service enablement.

Previously, the app used both `permission_handler` and the native OpenPath plugin for permissions, causing conflicts and preventing the OpenPath SDK from functioning correctly. This PR ensures all OpenPath-related permissions are managed solely by the native plugin and adds explicit prompts to guide users to enable Bluetooth and Location services if they are disabled, which are critical for the SDK.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ee05c48-b72c-4a56-8f8e-d565ece23683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ee05c48-b72c-4a56-8f8e-d565ece23683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

