### PR TITLE
Fix url_launcher_ios build error

### DIFF
--- a/fix_url_launcher_build.sh
+++ b/fix_url_launcher_build.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+echo "🔧 Fixing url_launcher iOS build issue..."
+
+# Navigate to project root
+cd "$(dirname "$0")"
+
+echo "📁 Current directory: $(pwd)"
+
+# Clean Flutter project
+echo "🧹 Cleaning Flutter project..."
+if command -v flutter &> /dev/null; then
+    flutter clean
+    flutter pub get
+else
+    echo "⚠️ Flutter command not found, skipping Flutter clean"
+fi
+
+# Clean iOS build
+echo "🧹 Cleaning iOS build..."
+cd ios
+rm -rf build/
+rm -rf Pods/
+rm -rf Podfile.lock
+
+# Reinstall pods
+echo "📦 Reinstalling CocoaPods dependencies..."
+if command -v pod &> /dev/null; then
+    pod install --repo-update
+else
+    echo "⚠️ CocoaPods not found, please install it first"
+    echo "   Run: sudo gem install cocoapods"
+fi
+
+echo "✅ Build fix complete!"
+echo ""
+echo "Next steps:"
+echo "1. Open ios/Runner.xcworkspace in Xcode"
+echo "2. Clean Build Folder (Cmd+Shift+K)"
+echo "3. Build the project (Cmd+B)"
+echo ""
+echo "The updated Podfile now copies the privacy bundle to both:"
+echo "- Frameworks folder: \${BUILT_PRODUCTS_DIR}/\${FRAMEWORKS_FOLDER_PATH}/url_launcher_ios_privacy.bundle"
+echo "- Target directory: \${BUILT_PRODUCTS_DIR}/url_launcher_ios/url_launcher_ios_privacy.bundle"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -111,10 +111,22 @@ post_install do |installer|
         PRIVACY_BUNDLE_SRC="${SRCROOT}/url_launcher_ios_privacy.bundle"
         PRIVACY_BUNDLE_DST="${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/url_launcher_ios_privacy.bundle"
         
+        # Also try the target-specific directory
+        TARGET_DST="${BUILT_PRODUCTS_DIR}/url_launcher_ios/url_launcher_ios_privacy.bundle"
+        
         if [ -d "${PRIVACY_BUNDLE_SRC}" ]; then
-          echo "Copying privacy bundle from ${PRIVACY_BUNDLE_SRC} to ${PRIVACY_BUNDLE_DST}"
+          echo "Copying privacy bundle from ${PRIVACY_BUNDLE_SRC}"
+          
+          # Copy to frameworks folder
           mkdir -p "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}"
           cp -R "${PRIVACY_BUNDLE_SRC}" "${PRIVACY_BUNDLE_DST}"
+          echo "✅ Copied to frameworks folder: ${PRIVACY_BUNDLE_DST}"
+          
+          # Copy to target-specific directory
+          mkdir -p "${BUILT_PRODUCTS_DIR}/url_launcher_ios"
+          cp -R "${PRIVACY_BUNDLE_SRC}" "${TARGET_DST}"
+          echo "✅ Copied to target directory: ${TARGET_DST}"
+          
           echo "✅ url_launcher_ios privacy bundle copied successfully"
         else
           echo "⚠️ Privacy bundle not found at ${PRIVACY_BUNDLE_SRC}"
@@ -283,11 +295,21 @@ post_install do |installer|
       # Copy url_launcher_ios privacy bundle
       URL_LAUNCHER_SRC="${SRCROOT}/url_launcher_ios_privacy.bundle"
       URL_LAUNCHER_DST="${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/url_launcher_ios_privacy.bundle"
+      URL_LAUNCHER_TARGET_DST="${BUILT_PRODUCTS_DIR}/url_launcher_ios/url_launcher_ios_privacy.bundle"
       
       if [ -d "${URL_LAUNCHER_SRC}" ]; then
         echo "Copying url_launcher_ios privacy bundle..."
+        
+        # Copy to frameworks folder
         mkdir -p "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}"
         cp -R "${URL_LAUNCHER_SRC}" "${URL_LAUNCHER_DST}"
+        echo "✅ Copied to frameworks folder: ${URL_LAUNCHER_DST}"
+        
+        # Copy to target-specific directory
+        mkdir -p "${BUILT_PRODUCTS_DIR}/url_launcher_ios"
+        cp -R "${URL_LAUNCHER_SRC}" "${URL_LAUNCHER_TARGET_DST}"
+        echo "✅ Copied to target directory: ${URL_LAUNCHER_TARGET_DST}"
+        
         echo "✅ url_launcher_ios privacy bundle copied"
       else
         echo "⚠️ url_launcher_ios privacy bundle not found at ${URL_LAUNCHER_SRC}"


### PR DESCRIPTION
Resolve `url_launcher_ios_privacy.bundle` build error by updating the Podfile to copy the bundle to all expected locations and adding a build fix script.

---
<a href="https://cursor.com/background-agent?bcId=bc-7236ab2d-d630-4980-ba06-07abe949b891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7236ab2d-d630-4980-ba06-07abe949b891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

